### PR TITLE
hotfix/id48/user-role-and-task-tag-insert

### DIFF
--- a/src/main/java/com/manolito/dashflow/loader/TasksDataWarehouseLoader.java
+++ b/src/main/java/com/manolito/dashflow/loader/TasksDataWarehouseLoader.java
@@ -115,6 +115,11 @@ public class TasksDataWarehouseLoader {
         }
     }
 
+    public void truncateTable(String tableName) {
+        String fullTableName = "dw_tasks." + tableName;
+        spark.sql("TRUNCATE TABLE " + fullTableName);
+    }
+
     public void saveWithRetries(Dataset<Row> data, String tableName, int maxRetries) {
         int attempts = 0;
         while (attempts < maxRetries) {

--- a/src/main/java/com/manolito/dashflow/loader/TasksDataWarehouseLoader.java
+++ b/src/main/java/com/manolito/dashflow/loader/TasksDataWarehouseLoader.java
@@ -117,7 +117,13 @@ public class TasksDataWarehouseLoader {
 
     public void truncateTable(String tableName) {
         String fullTableName = "dw_tasks." + tableName;
-        spark.sql("TRUNCATE TABLE " + fullTableName);
+        try {
+            if (spark.catalog().tableExists("dw_tasks", tableName)) {
+                spark.sql("TRUNCATE TABLE " + fullTableName);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to truncate table " + tableName, e);
+        }
     }
 
     public void saveWithRetries(Dataset<Row> data, String tableName, int maxRetries) {

--- a/src/main/java/com/manolito/dashflow/loader/TasksDataWarehouseLoader.java
+++ b/src/main/java/com/manolito/dashflow/loader/TasksDataWarehouseLoader.java
@@ -98,8 +98,9 @@ public class TasksDataWarehouseLoader {
     public void save(Dataset<Row> data, String tableName) {
         try {
             List<String> tableColumns = sparkUtils.fetchTableColumns(jdbcUrl, dbUser, dbPassword, tableName);
-
             Dataset<Row> filteredData = data.select(sparkUtils.getColumns(data, tableColumns));
+
+            SaveMode mode = isLinkTable(tableName) ? SaveMode.Overwrite : SaveMode.Append;
 
             filteredData.write()
                     .format("jdbc")
@@ -108,11 +109,15 @@ public class TasksDataWarehouseLoader {
                     .option("user", dbUser)
                     .option("password", dbPassword)
                     .option("batchsize", 10000)
-                    .mode(SaveMode.Append)
+                    .mode(mode)
                     .save();
         } catch (Exception e) {
             throw new RuntimeException("Error saving data to table: " + tableName, e);
         }
+    }
+
+    private boolean isLinkTable(String tableName) {
+        return tableName.equals("user_role") || tableName.equals("task_tag");
     }
 
     public void truncateTable(String tableName) {

--- a/src/main/java/com/manolito/dashflow/service/dw/TaigaService.java
+++ b/src/main/java/com/manolito/dashflow/service/dw/TaigaService.java
@@ -209,10 +209,11 @@ public class TaigaService {
                         pair -> pair[0]
                 ));
     };
-    
-    public Dataset<Row> saveUserRoleToDatabase() {
 
+    public Dataset<Row> saveUserRoleToDatabase() {
         try {
+            dataWarehouseLoader.truncateTable("user_role");
+
             Dataset<Row> userRolePairs = handleProjects()
                     .withColumn("member", explode(col("members")))
                     .select(
@@ -244,6 +245,8 @@ public class TaigaService {
 
     public Dataset<Row> saveTaskTagToDatabase() {
         try {
+            dataWarehouseLoader.truncateTable("task_tag");
+
             Dataset<Row> taskTagPairs = handleTasks()
                     .withColumn("tag", explode(col("tags")))
                     .select(
@@ -268,7 +271,6 @@ public class TaigaService {
                     .join(tags, "tag_name", "inner")
                     .select("task_id", "tag_id")
                     .orderBy("task_id", "tag_id");
-
         } catch (Exception e) {
             throw new RuntimeException("Failed to save task tags", e);
         }

--- a/src/main/java/com/manolito/dashflow/service/dw/TaigaService.java
+++ b/src/main/java/com/manolito/dashflow/service/dw/TaigaService.java
@@ -211,7 +211,6 @@ public class TaigaService {
     };
     
     public Dataset<Row> saveUserRoleToDatabase() {
-        final long projectId = 1637322L;
 
         try {
             Dataset<Row> userRolePairs = handleProjects()


### PR DESCRIPTION
This fixes the issue of inserting an already existing row in a many-to-many table that doesn't have a sequential ID by purging the content of the tables before an insertion attempt.