### PR TITLE
feat: R11/id78/total tasks by status by project

### DIFF
--- a/src/main/java/com/manolito/dashflow/controller/application/StatusController.java
+++ b/src/main/java/com/manolito/dashflow/controller/application/StatusController.java
@@ -48,4 +48,28 @@ public class StatusController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Internal Server Error " + runtimeException.getMessage());
         }
     }
+
+    @GetMapping("/{projectId}")
+    @Operation(summary = "Busca a soma de tasks por status de um projeto",
+            description = "Faz uma requisição ao DB e retorna o nome do status e a quantidade de tasks referentes a ela em projeto")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Quantidade de status extraída com sucesso."),
+            @ApiResponse(responseCode = "400", description = "Requisição mal formulada."),
+            @ApiResponse(responseCode = "404", description = "Status para o projeto não existem."),
+            @ApiResponse(responseCode = "408", description = "Tempo de resposta excedido."),
+            @ApiResponse(responseCode = "500", description = "Erro interno do servidor ao tentar buscar o local.")
+    })
+    public ResponseEntity<?> getTaskCountGroupByStatusByProjectId(
+            @Parameter(description = "Id do projeto", required = true) @PathVariable String projectId
+    ) {
+        try {
+            return ResponseEntity.ok().body(statusService.getTaskCountGroupByStatusByProjectId(projectId));
+        } catch (NoSuchElementException noSuchElementException) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } catch (IllegalArgumentException illegalArgumentException) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (RuntimeException runtimeException) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Internal Server Error " + runtimeException.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/manolito/dashflow/controller/application/StatusController.java
+++ b/src/main/java/com/manolito/dashflow/controller/application/StatusController.java
@@ -36,7 +36,7 @@ public class StatusController {
     })
     public ResponseEntity<?> getTaskCountGroupByStatusByUserIdAndProjectId(
             @Parameter(description = "Id do usuário", required = true) @PathVariable Integer userId,
-            @Parameter(description = "Id do projeto", required = true) @PathVariable Integer projectId
+            @Parameter(description = "Id do projeto", required = true) @PathVariable String projectId
     ) {
         try {
             return ResponseEntity.ok().body(statusService.getTaskCountGroupByStatusByUserIdAndProjectId(userId, projectId));

--- a/src/main/java/com/manolito/dashflow/repository/application/TasksDataWarehouseRepository.java
+++ b/src/main/java/com/manolito/dashflow/repository/application/TasksDataWarehouseRepository.java
@@ -161,7 +161,7 @@ public class TasksDataWarehouseRepository {
         }
     }
 
-    public List<StatusCountDto> getTaskCountGroupByStatusByUserIdAndProjectId(int userId, int projectId) {
+    public List<StatusCountDto> getTaskCountGroupByStatusByUserIdAndProjectId(int userId, String projectId) {
         String sql = "SELECT st.status_name, COUNT(ft.task_id) as task_count " +
                 "FROM dashflow_appl.users u " +
                 "LEFT JOIN dashflow_appl.accounts acc " +
@@ -182,7 +182,7 @@ public class TasksDataWarehouseRepository {
 
         Map<String, Object> params = new HashMap<>();
         params.put("userId", userId);
-        params.put("projectId", String.valueOf(projectId));
+        params.put("projectId", projectId);
 
         return jdbcTemplate.query(
                 sql,

--- a/src/main/java/com/manolito/dashflow/repository/application/TasksDataWarehouseRepository.java
+++ b/src/main/java/com/manolito/dashflow/repository/application/TasksDataWarehouseRepository.java
@@ -194,6 +194,31 @@ public class TasksDataWarehouseRepository {
         );
     }
 
+    public List<StatusCountDto> getTaskCountGroupByStatusByProjectId(String projectId) {
+        String sql = "SELECT st.status_name, COUNT(ft.task_id) as task_count " +
+                "FROM dw_tasks.projects prj " +
+                "LEFT JOIN dw_tasks.epics ep ON prj.project_id = ep.project_id " +
+                "LEFT JOIN dw_tasks.stories sto ON ep.epic_id = sto.epic_id " +
+                "LEFT JOIN dw_tasks.fact_tasks ft ON sto.story_id = ft.story_id " +
+                "LEFT JOIN dw_tasks.status st " +
+                "ON ft.status_id = st.status_id " +
+                "WHERE prj.original_id = :projectId " +
+                "AND st.is_current = TRUE " +
+                "GROUP BY st.status_name";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("projectId", projectId);
+
+        return jdbcTemplate.query(
+                sql,
+                params,
+                (rs, rowNum) -> new StatusCountDto(
+                        rs.getString("status_name"),
+                        rs.getInt("task_count")
+                )
+        );
+    }
+
     public Optional<Double> getAverageTimeCard(Integer userId) {
         String sql = "SELECT ROUND((AVG(completed.date_date - created.date_date)/3),2) AS average_time " +
                 "FROM dw_tasks.fact_tasks ft " +

--- a/src/main/java/com/manolito/dashflow/service/application/StatusService.java
+++ b/src/main/java/com/manolito/dashflow/service/application/StatusService.java
@@ -74,6 +74,9 @@ public class StatusService {
         List<StatusCountDto> statusCountDto = tasksDataWarehouseRepository.getTaskCountGroupByStatusByProjectId(
                 projectId
         );
+        if (projectId == null) {
+            throw new NullPointerException("projectId cannot be null");
+        }
         if (statusCountDto.isEmpty()) {
             throw new NoSuchElementException("No statuses found");
         }

--- a/src/main/java/com/manolito/dashflow/service/application/StatusService.java
+++ b/src/main/java/com/manolito/dashflow/service/application/StatusService.java
@@ -45,4 +45,35 @@ public class StatusService {
         }
         return statusCountDto;
     }
+
+    /**
+     * Retrieves the count of tasks grouped by status for a specific project.
+     * <p>
+     * This method queries the data warehouse to get the number of tasks in each status
+     * for the given project. Only the current version of tasks and statuses are considered.
+     * </p>
+     *
+     * @param projectId the ID of the project to filter tasks by (must not be null)
+     * @return a list of {@link StatusCountDto} objects containing status names and corresponding task counts
+     * @throws NoSuchElementException if no status information is found for the given project
+     * @throws NullPointerException if projectId is null
+     * @see StatusCountDto
+     * @see TasksDataWarehouseRepository#getTaskCountGroupByStatusByProjectId(String)
+     *
+     * @example
+     * <pre>{@code
+     * // Get status counts for project 777
+     * List<StatusCountDto> statusCounts = statusService
+     *     .getTaskCountGroupByStatusByProjectId("777");
+     * }</pre>
+     */
+    public List<StatusCountDto> getTaskCountGroupByStatusByProjectId(String projectId) {
+        List<StatusCountDto> statusCountDto = tasksDataWarehouseRepository.getTaskCountGroupByStatusByProjectId(
+                projectId
+        );
+        if (statusCountDto.isEmpty()) {
+            throw new NoSuchElementException("No statuses found");
+        }
+        return statusCountDto;
+    }
 }

--- a/src/main/java/com/manolito/dashflow/service/application/StatusService.java
+++ b/src/main/java/com/manolito/dashflow/service/application/StatusService.java
@@ -27,7 +27,7 @@ public class StatusService {
      * @throws NoSuchElementException if no status information is found for the given user and project
      * @throws NullPointerException if either userId or projectId is null
      * @see StatusCountDto
-     * @see TasksDataWarehouseRepository#getTaskCountGroupByStatusByUserIdAndProjectId(int, int)
+     * @see TasksDataWarehouseRepository#getTaskCountGroupByStatusByUserIdAndProjectId(int, String)
      *
      * @example
      * <pre>{@code
@@ -36,10 +36,13 @@ public class StatusService {
      *     .getTaskCountGroupByStatusByUserIdAndProjectId(123, 456);
      * }</pre>
      */
-    public List<StatusCountDto> getTaskCountGroupByStatusByUserIdAndProjectId(Integer userId, Integer projectId) {
+    public List<StatusCountDto> getTaskCountGroupByStatusByUserIdAndProjectId(Integer userId, String projectId) {
         List<StatusCountDto> statusCountDto = tasksDataWarehouseRepository.getTaskCountGroupByStatusByUserIdAndProjectId(
                 userId, projectId
         );
+        if (projectId == null) {
+            throw new NullPointerException("projectId cannot be null");
+        }
         if (statusCountDto.isEmpty()) {
             throw new NoSuchElementException("No statuses found");
         }

--- a/src/test/java/com/manolito/dashflow/service/StatusServiceTest.java
+++ b/src/test/java/com/manolito/dashflow/service/StatusServiceTest.java
@@ -83,4 +83,51 @@ class StatusServiceTest {
         verify(tasksDataWarehouseRepository, never())
                 .getTaskCountGroupByStatusByUserIdAndProjectId(anyInt(), anyString());
     }
+
+    @Test
+    @DisplayName("Should return task counts grouped by status when valid project ID is provided")
+    void getTaskCountGroupByStatusByProjectId_shouldReturnStatusCounts() {
+        List<StatusCountDto> expectedResults = List.of(
+                new StatusCountDto("To Do", 10),
+                new StatusCountDto("In Progress", 6),
+                new StatusCountDto("Done", 4)
+        );
+
+        when(tasksDataWarehouseRepository.getTaskCountGroupByStatusByProjectId(TEST_PROJECT_ID))
+                .thenReturn(expectedResults);
+
+        List<StatusCountDto> actualResults = statusService.getTaskCountGroupByStatusByProjectId(TEST_PROJECT_ID);
+
+        assertNotNull(actualResults);
+        assertEquals(3, actualResults.size());
+        assertEquals("To Do", actualResults.get(0).getStatusName());
+        assertEquals(10, actualResults.get(0).getCount());
+        verify(tasksDataWarehouseRepository, times(1))
+                .getTaskCountGroupByStatusByProjectId(TEST_PROJECT_ID);
+    }
+
+    @Test
+    @DisplayName("Should throw NoSuchElementException when no task status counts are found for project")
+    void getTaskCountGroupByStatusByProjectId_whenNoResults_shouldThrowException() {
+        when(tasksDataWarehouseRepository.getTaskCountGroupByStatusByProjectId(anyString()))
+                .thenReturn(Collections.emptyList());
+
+        assertThrows(NoSuchElementException.class, () ->
+                statusService.getTaskCountGroupByStatusByProjectId(TEST_PROJECT_ID)
+        );
+
+        verify(tasksDataWarehouseRepository, times(1))
+                .getTaskCountGroupByStatusByProjectId(TEST_PROJECT_ID);
+    }
+
+    @Test
+    @DisplayName("Should throw NullPointerException when project ID is null")
+    void getTaskCountGroupByStatusByProjectId_withNullInput_shouldThrowException() {
+        assertThrows(NullPointerException.class, () ->
+                statusService.getTaskCountGroupByStatusByProjectId(null)
+        );
+
+        verify(tasksDataWarehouseRepository, never())
+                .getTaskCountGroupByStatusByProjectId(anyString());
+    }
 }

--- a/src/test/java/com/manolito/dashflow/service/StatusServiceTest.java
+++ b/src/test/java/com/manolito/dashflow/service/StatusServiceTest.java
@@ -28,7 +28,7 @@ class StatusServiceTest {
     private StatusService statusService;
 
     private final int TEST_USER_ID = 123;
-    private final int TEST_PROJECT_ID = 456;
+    private final String TEST_PROJECT_ID = "456";
 
     @Test
     @DisplayName("Should return task counts grouped by status when valid user and project IDs are provided")
@@ -58,7 +58,7 @@ class StatusServiceTest {
     @DisplayName("Should throw NoSuchElementException when no task status counts are found")
     void getTaskCountGroupByStatusByUserIdAndProjectId_whenNoResults_shouldThrowException() {
         when(tasksDataWarehouseRepository.getTaskCountGroupByStatusByUserIdAndProjectId(
-                anyInt(), anyInt()))
+                anyInt(), anyString()))
                 .thenReturn(Collections.emptyList());
 
         assertThrows(NoSuchElementException.class, () ->
@@ -81,6 +81,6 @@ class StatusServiceTest {
         );
 
         verify(tasksDataWarehouseRepository, never())
-                .getTaskCountGroupByStatusByUserIdAndProjectId(anyInt(), anyInt());
+                .getTaskCountGroupByStatusByUserIdAndProjectId(anyInt(), anyString());
     }
 }


### PR DESCRIPTION
This adds the following:
+ repo query, service and controller endpoint to get Tasks grouped by Statuses for a given projectId
+ docs and tests for the new feature
+ minor: updates the projectId form Integer to String of another StatusService method