### PR TITLE
feat: R15/id44/task count by tag by projectid

### DIFF
--- a/src/main/java/com/manolito/dashflow/controller/application/TasksController.java
+++ b/src/main/java/com/manolito/dashflow/controller/application/TasksController.java
@@ -196,4 +196,27 @@ public class TasksController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Internal Server Error " + runtimeException.getMessage());
         }
     }
+
+    @GetMapping("/get-by-tag/{projectId}")
+    @Operation(summary = "Busca o total de tasks por tags de um projeto", description = "Faz uma requisição ao DB e retorna o total de Tasks associadas a cada tag de um projeto")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Total de tasks por tag extraido com sucesso."),
+            @ApiResponse(responseCode = "400", description = "Requisição mal formulada."),
+            @ApiResponse(responseCode = "404", description = "Tasks não existem."),
+            @ApiResponse(responseCode = "408", description = "Tempo de resposta excedido."),
+            @ApiResponse(responseCode = "500", description = "Erro interno do servidor ao tentar buscar tasks por tags de um projeto.")
+    })
+    public ResponseEntity<?> getTotalTasksByTagByProjectId(
+            @Parameter(description = "Id do usuario", required = true) @PathVariable String projectId
+    ) {
+        try {
+            return ResponseEntity.ok().body(tasksService.getTaskCountByTagByProjectId(projectId));
+        } catch (NoSuchElementException noSuchElementException) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(noSuchElementException.getMessage());
+        } catch (IllegalArgumentException illegalArgumentException) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (RuntimeException runtimeException) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Internal Server Error " + runtimeException.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/manolito/dashflow/dto/dw/TaskTagDto.java
+++ b/src/main/java/com/manolito/dashflow/dto/dw/TaskTagDto.java
@@ -1,0 +1,13 @@
+package com.manolito.dashflow.dto.dw;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TaskTagDto {
+    private String tagName;
+    private Integer count;
+}

--- a/src/main/java/com/manolito/dashflow/repository/application/TasksDataWarehouseRepository.java
+++ b/src/main/java/com/manolito/dashflow/repository/application/TasksDataWarehouseRepository.java
@@ -2,6 +2,7 @@ package com.manolito.dashflow.repository.application;
 
 import com.manolito.dashflow.dto.dw.CreatedDoneDto;
 import com.manolito.dashflow.dto.dw.StatusCountDto;
+import com.manolito.dashflow.dto.dw.TaskTagDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -281,5 +282,34 @@ public class TasksDataWarehouseRepository {
         } catch (EmptyResultDataAccessException e) {
             return Optional.empty();
         }
+    }
+
+    public List<TaskTagDto> getTaskCountGroupByTagByProjectId(String projectId) {
+        String sql = "SELECT tag.tag_name, COUNT(ft.task_id) as task_count " +
+                "FROM dw_tasks.projects prj " +
+                "LEFT JOIN dw_tasks.epics ep ON prj.project_id = ep.project_id " +
+                "LEFT JOIN dw_tasks.stories sto ON ep.epic_id = sto.epic_id " +
+                "LEFT JOIN dw_tasks.fact_tasks ft ON sto.story_id = ft.story_id " +
+                "LEFT JOIN dw_tasks.status st " +
+                "ON ft.status_id = st.status_id " +
+                "LEFT JOIN dw_tasks.task_tag tt" +
+                "ON tt.task_id = ft.task_id " +
+                "LEFT JOIN dw_tasks.tags tag " +
+                "ON tt.tag_id = tag.tag_id "+
+                "WHERE prj.original_id = :projectId " +
+                "AND tag.is_current = TRUE " +
+                "GROUP BY tag.tag_name";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("projectId", projectId);
+
+        return jdbcTemplate.query(
+                sql,
+                params,
+                (rs, rowNum) -> new TaskTagDto(
+                        rs.getString("tag_name"),
+                        rs.getInt("task_count")
+                )
+        );
     }
 }

--- a/src/main/java/com/manolito/dashflow/service/application/TasksService.java
+++ b/src/main/java/com/manolito/dashflow/service/application/TasksService.java
@@ -1,6 +1,7 @@
 package com.manolito.dashflow.service.application;
 
 import com.manolito.dashflow.dto.dw.CreatedDoneDto;
+import com.manolito.dashflow.dto.dw.TaskTagDto;
 import com.manolito.dashflow.repository.application.TasksDataWarehouseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -149,5 +150,24 @@ public class TasksService {
             throw new NoSuchElementException("No cards found for this manager");
         }
         return cardsCount.get();
+    }
+
+    /**
+     * Retrieves a list of task counts grouped by their tags for a specific project.
+     * Each element in the list contains the task tag and the corresponding count.
+     *
+     * @param projectId the ID of the project to query tasks for
+     * @return a list of {@link TaskTagDto} objects representing task counts by tags
+     * @throws NoSuchElementException if no tasks are found within the given date range
+     */
+    public List<TaskTagDto> getTaskCountByTagByProjectId(String projectId) {
+        List<TaskTagDto> taskCount = tasksDataWarehouseRepository.getTaskCountGroupByTagByProjectId(projectId);
+        if (projectId == null) {
+            throw new IllegalArgumentException("projectId cannot be null");
+        }
+        if (taskCount.isEmpty()) {
+            throw new NoSuchElementException("No tasks found");
+        }
+        return taskCount;
     }
 }

--- a/src/test/java/com/manolito/dashflow/service/TasksServiceTest.java
+++ b/src/test/java/com/manolito/dashflow/service/TasksServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import java.util.*;
 
 import com.manolito.dashflow.dto.dw.CreatedDoneDto;
+import com.manolito.dashflow.dto.dw.TaskTagDto;
 import com.manolito.dashflow.repository.application.TasksDataWarehouseRepository;
 import com.manolito.dashflow.service.application.TasksService;
 import org.junit.jupiter.api.DisplayName;
@@ -283,5 +284,51 @@ class TasksServiceTest {
 
         assertEquals("projectId cannot be null", exception.getMessage());
         verify(tasksDataWarehouseRepository, never()).getAverageTimeCardByProjectId(anyString());
+    }
+
+    @Test
+    @DisplayName("getTaskCountByTagByProjectId - should return task counts by tag when tasks exist")
+    void getTaskCountByTagByProjectId_whenTasksExist_shouldReturnCounts() {
+        List<TaskTagDto> expectedResults = List.of(
+                new TaskTagDto("UI", 5),
+                new TaskTagDto("Backend", 3),
+                new TaskTagDto("Bug", 2)
+        );
+
+        when(tasksDataWarehouseRepository.getTaskCountGroupByTagByProjectId(TEST_PROJECT_ID))
+                .thenReturn(expectedResults);
+
+        List<TaskTagDto> actualResults = tasksService.getTaskCountByTagByProjectId(TEST_PROJECT_ID);
+
+        assertNotNull(actualResults);
+        assertEquals(3, actualResults.size());
+        assertEquals("UI", actualResults.get(0).getTagName());
+        assertEquals(5, actualResults.get(0).getCount());
+        assertEquals("Backend", actualResults.get(1).getTagName());
+        assertEquals(3, actualResults.get(1).getCount());
+        verify(tasksDataWarehouseRepository).getTaskCountGroupByTagByProjectId(TEST_PROJECT_ID);
+    }
+
+    @Test
+    @DisplayName("getTaskCountByTagByProjectId - should throw when no tasks found")
+    void getTaskCountByTagByProjectId_whenNoTasks_shouldThrow() {
+        when(tasksDataWarehouseRepository.getTaskCountGroupByTagByProjectId(TEST_PROJECT_ID))
+                .thenReturn(Collections.emptyList());
+
+        NoSuchElementException exception = assertThrows(NoSuchElementException.class,
+                () -> tasksService.getTaskCountByTagByProjectId(TEST_PROJECT_ID));
+
+        assertEquals("No tasks found", exception.getMessage());
+        verify(tasksDataWarehouseRepository).getTaskCountGroupByTagByProjectId(TEST_PROJECT_ID);
+    }
+
+    @Test
+    @DisplayName("getTaskCountByTagByProjectId - should throw when projectId is null")
+    void getTaskCountByTagByProjectId_whenProjectIdIsNull_shouldThrow() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> tasksService.getTaskCountByTagByProjectId(null));
+
+        assertEquals("projectId cannot be null", exception.getMessage());
+        verify(tasksDataWarehouseRepository, never()).getTaskCountGroupByTagByProjectId(anyString());
     }
 }


### PR DESCRIPTION
This adds the following:
+ repository query to gather tasks by tag for a given project
+ service layer that handles throws and returns the query to the controller
+ controlley layer access endpoint for the query
+ unit tests for the service layer
+ new dto for the result set of tasks count and tag names